### PR TITLE
Git hub link

### DIFF
--- a/src/shared/components/Navbars/Navbar.vue
+++ b/src/shared/components/Navbars/Navbar.vue
@@ -50,7 +50,7 @@
 
             <a
                     class="cta flex items-center justify-center"
-                    href="/resume"
+                    href="https://piuskariuki.github.io/resume/resume.pdf"
             >
                 Resume`
             </a>

--- a/src/shared/components/Sidebars/Sidebar.vue
+++ b/src/shared/components/Sidebars/Sidebar.vue
@@ -23,7 +23,7 @@
                 </a>
                 <a
                         class="cta py-2 mt-4 flex justify-center"
-                        href="/resume">Resume`</a>
+                        href="https://piuskariuki.github.io/resume/resume.pdf">Resume`</a>
             </div>
 
         </div>


### PR DESCRIPTION
Browsers block iframes so now just make direct links to the github pdf